### PR TITLE
Error resolved while adding new contacts. Please merge

### DIFF
--- a/android-mapper/src/main/java/ezvcard/android/ContactOperations.java
+++ b/android-mapper/src/main/java/ezvcard/android/ContactOperations.java
@@ -89,13 +89,10 @@ public class ContactOperations {
 		account.put(ContactsContract.RawContacts.ACCOUNT_NAME, accountName);
 	}
 
-	@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 	public void insertContact(VCard vcard) throws RemoteException, OperationApplicationException {
 		// TODO handle Raw properties - Raw properties include various extension which start with "X-" like X-ASSISTANT, X-AIM, X-SPOUSE
 
 		List<NonEmptyContentValues> contentValues = new ArrayList<NonEmptyContentValues>();
-		contentValues.add(account);
-
 		convertName(contentValues, vcard);
 		convertNickname(contentValues, vcard);
 		convertPhones(contentValues, vcard);
@@ -118,14 +115,21 @@ public class ContactOperations {
 		convertOrganization(contentValues, vcard);
 
 		ArrayList<ContentProviderOperation> operations = new ArrayList<ContentProviderOperation>(contentValues.size());
+		ContentValues cv = account.getContentValues();
+		//ContactsContract.RawContact.CONTENT_URI needed to add account, backReference is also not needed
+		ContentProviderOperation operation =
+				ContentProviderOperation.newInsert(ContactsContract.RawContacts.CONTENT_URI) 
+						.withValues(cv)
+						.build();
+		operations.add(operation);
 		for (NonEmptyContentValues values : contentValues) {
-			ContentValues cv = values.getContentValues();
+			cv = values.getContentValues();
 			if (cv.size() == 0) {
 				continue;
 			}
 
 			//@formatter:off
-			ContentProviderOperation operation =
+			operation =
 				ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
 				.withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, rawContactID)
 				.withValues(cv)


### PR DESCRIPTION
 E/ContentProviderOperation: mType: 1, mUri: content://com.android.contacts/data, mSelection: null, mExpectedCount: null, mYieldAllowed: false, mValues: data1=Aakash2 data2=Aakash2 mimetype=vnd.android.cursor.item/name, mValuesBackReferences: raw_contact_id=0, mSelectionArgsBackReferences: null<br>
E/JavaBinder: *** Uncaught remote exception! (Exceptions are not yet supported across processes.)
java.lang.ArrayIndexOutOfBoundsException: asked for back ref 0 but there are only 0 back refs
at android.content.ContentProviderOperation.backRefToValue(ContentProviderOperation.java:393)<br><br>

Above error occurs while adding contacts because account is added like not added as it was added before it was given a wrong value in ContentProviderOperation's newInsert() function and also not contains backReference<br>